### PR TITLE
Fix format of modern w2v models

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ model.pprint( model.rank("apple", Set("orange", "soda", "lettuce")) )
 
 ## Compatibility
 
-- **[09/2013]** The code was tested to work with models trained using revision
-[r33](http://word2vec.googlecode.com/svn/trunk/?p=33) of the word2vec toolkit.
+- **[06/2016]** The code was tested to work with models trained using 
+[gensim 0.12.4](https://github.com/RaRe-Technologies/gensim).
 It should also work with future revisions, assuming that the output format does
 not change.

--- a/src/main/scala/word2vec/Reader.scala
+++ b/src/main/scala/word2vec/Reader.scala
@@ -104,8 +104,9 @@ object VecBinaryReader {
       vector(i) = f
     }
 
-    // Eat up the next delimiter character
-    reader.read[Byte]
+    // Modern tools like gensim stores model without delimiter character after last element of each vector
+//    // Eat up the next delimiter character
+//    reader.read[Byte]
 
     // Store the normalized vector representation, keyed by the word
     word -> (if (normalize) normVector(vector) else vector)

--- a/src/main/scala/word2vec/Reader.scala
+++ b/src/main/scala/word2vec/Reader.scala
@@ -45,9 +45,9 @@ object TypeReader {
 }
 
 /** A simple binary file reader.
+  *
   * @constructor Create a binary file reader.
   * @param file The binary file to be read.
-  *
   * @author trananh
   */
 class VecBinaryReader(file: File) {
@@ -83,6 +83,7 @@ object VecBinaryReader {
   }
 
   /** Compute the magnitude of the vector.
+    *
     * @param vec The vector.
     * @return The magnitude of the vector.
     */
@@ -95,7 +96,7 @@ object VecBinaryReader {
     vec.map(a => (a / norm).toFloat)
   }
 
-  def readVector(reader: VecBinaryReader, vecSize:Int, normalize: Boolean): (String, Array[Float]) = {
+  def readVector(reader: VecBinaryReader, vecSize:Int, normalize: Boolean, oldFormat: Boolean): (String, Array[Float]) = {
      // Read the word
     val word = reader.read[String]
 
@@ -105,21 +106,22 @@ object VecBinaryReader {
     }
 
     // Modern tools like gensim stores model without delimiter character after last element of each vector
-//    // Eat up the next delimiter character
-//    reader.read[Byte]
-
+    if (oldFormat) {
+      // Eat up the next delimiter character
+      reader.read[Byte]
+    }
     // Store the normalized vector representation, keyed by the word
     word -> (if (normalize) normVector(vector) else vector)
   }
 
-  def load(filename: String, limit: Integer = Int.MaxValue, normalize: Boolean = true): Option[Vocab] = {
-    for(file <- loadFile(filename)) yield VecBinaryReader.withReader(file) { reader => 
+  def load(filename: String, limit: Integer = Int.MaxValue, normalize: Boolean = true, oldFormat: Boolean): Option[Vocab] = {
+    for(file <- loadFile(filename)) yield VecBinaryReader.withReader(file) { reader =>
       // Read header info
       val numWords = reader.read[Int]
       val vecSize = reader.read[Int]
       println("\nFile contains " + numWords + " words with vector size " + vecSize)
 
-      def wordPairs = Stream.continually(readVector(reader, vecSize, normalize))
+      def wordPairs = Stream.continually(readVector(reader, vecSize, normalize, oldFormat))
       val N = numWords.min(limit)
 
       val map = wordPairs.take(N).toMap

--- a/src/main/scala/word2vec/Word2Vec.scala
+++ b/src/main/scala/word2vec/Word2Vec.scala
@@ -231,9 +231,10 @@ object Word2Vec {
     * @param filename Path to file containing word projections in the BINARY FORMAT.
     * @param limit Maximum number of words to load from file (a.k.a. max vocab size).
     * @param normalize Normalize the loaded vectors if true (default to true).
+    * @param oldFormat Load model stored in old format - with delimiter between vectors (default to false).
     */
-  def apply(filename: String, limit: Integer = Int.MaxValue, normalize: Boolean = true): Option[Word2Vec] = {
-    for(v <- VecBinaryReader.load(filename, limit, normalize)) yield {
+  def apply(filename: String, limit: Integer = Int.MaxValue, normalize: Boolean = true, oldFormat: Boolean = false): Option[Word2Vec] = {
+    for(v <- VecBinaryReader.load(filename, limit, normalize, oldFormat)) yield {
       new Word2Vec(v.vectors, v.size, normalize)
     }
   }

--- a/src/main/scala/word2vec/Word2Vec.scala
+++ b/src/main/scala/word2vec/Word2Vec.scala
@@ -248,7 +248,7 @@ object RunWord2Vec {
   /** Demo. */
   def main(args: Array[String]) {
     // Load word2vec model from binary file.
-    val model = Word2Vec("../word2vec-scala/vectors.bin").get
+    val model = Word2Vec("vectors.bin").get
 
     // distance: Find N closest words
     model.pprint(model.distance(List("france"), N = 10).get)

--- a/src/main/scala/word2vec/Word2Vec.scala
+++ b/src/main/scala/word2vec/Word2Vec.scala
@@ -39,7 +39,7 @@ import spire.implicits._
   *
   * @author trananh
   */
-class Word2Vec(vocab: Map[String, Array[Float]], vecSize: Int) {
+class Word2Vec(vocab: Map[String, Array[Float]], vecSize: Int, normalized: Boolean) {
 
   /** Number of words */
   private val numWords = vocab.size
@@ -94,9 +94,13 @@ class Word2Vec(vocab: Map[String, Array[Float]], vecSize: Int) {
   def cosine(vec1: Array[Float], vec2: Array[Float]): Double = {
     assert(vec1.length == vec2.length, "Uneven vectors!")
     val dot = vec1 dot vec2
-    val sum1 = vec1 dot vec1
-    val sum2 = vec2 dot vec2
-    dot / (sum1.sqrt * sum2.sqrt)
+    if (normalized) {
+      dot
+    } else {
+      val sum1 = vec1 dot vec1
+      val sum2 = vec2 dot vec2
+      dot / (sum1.sqrt * sum2.sqrt)
+    }
   }
 
   /** Compute the cosine similarity score between the vector representations of the words.
@@ -110,13 +114,11 @@ class Word2Vec(vocab: Map[String, Array[Float]], vecSize: Int) {
     }
   }
   
-  /** Find the vector representation for the given list of word(s) by aggregating (summing) the
-    * vector for each word.
-    * @param input The input word(s).
+  /** Aggregate (sum) the given list of vectors
+    * @param vecs The input vector(s).
     * @return The sum vector (aggregated from the input vectors).
     */
   private def sumVector(vecs: List[Array[Float]]): Array[Float] = {
-    // Find the vector representation for the input. If multiple words, then aggregate (sum) their vectors.
     vecs reduce {_+_}
   }
 
@@ -232,7 +234,7 @@ object Word2Vec {
     */
   def apply(filename: String, limit: Integer = Int.MaxValue, normalize: Boolean = true): Option[Word2Vec] = {
     for(v <- VecBinaryReader.load(filename, limit, normalize)) yield {
-      new Word2Vec(v.vectors, v.size)
+      new Word2Vec(v.vectors, v.size, normalize)
     }
   }
 


### PR DESCRIPTION
Currently gensim produces model in binary format that doesn't have delimiters after each vector, so it can't be loaded and used by current code. I fixed that, replaced vectors.bin by new version, moved it to root (since it shouldn't be placed in jar, because it is used only for testing/demo).
Also I made a few other minor improvements: fixed outdated documentation and removed unnecessary normalization of vectors during cosine in case of already normalized model.
